### PR TITLE
add TYPE_CHECKING gate

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,11 @@
-# app.py
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:  # pragma: no cover
+    # Put future Protocol/TypedDict/etc. imports here
+    pass
+
+__version__: str = "0.1.0"
+__author__: str = "Contributors"# app.py
 import os
 import sys
 import json


### PR DESCRIPTION
Lets you add heavy type-only imports later with zero runtime cost.