### PR TITLE
add a library-friendly logger

### DIFF
--- a/selector_report.py
+++ b/selector_report.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
+"""Generate selector soundness reports from CSV inputs.
+
+Importing this module has no side effects; all behavior is opt-in via functions/CLI.
+"""
 from __future__ import annotations
+
+__version__: str = "0.1.0"
+__author__: str = "Contributors"
+from __future__ import annotations
+
+import logging
+
+# Library-friendly logger (silent unless configured by the host app)
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
 
 import argparse
 import collections


### PR DESCRIPTION
Avoids “No handler found” warnings; stays quiet unless configured by the host app.