### PR TITLE
add TYPE_CHECKING gate for future type-only imports

### DIFF
--- a/selector_report.py
+++ b/selector_report.py
@@ -7,6 +7,11 @@ import csv
 import datetime as dt
 import pathlib
 import statistics
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:  # pragma: no cover
+    # Future type-only imports go here (e.g., from typing_extensions import TypedDict)
+    pass
+
 from typing import Iterable, List, Tuple, Dict, Any
 
 


### PR DESCRIPTION
Lets you add heavy typing (Protocols, TypedDicts) without runtime cost.