### PR TITLE
centralize default column names

### DIFF
--- a/selector_report.py
+++ b/selector_report.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+# Default CSV column names (used by CLI and helpers)
+DEFAULT_ID_COL = "id"
+DEFAULT_TRUTH_COL = "y_true"
+DEFAULT_PRED_COL = "y_pred"
+DEFAULT_SELECTOR_COL = "selector"
 
 import argparse
 import collections


### PR DESCRIPTION
Avoids magic strings; makes CLI defaults & docs consistent.