### PR TITLE
Library-friendly logger

### DIFF
--- a/selector_report.py
+++ b/selector_report.py
@@ -10,6 +10,12 @@ import statistics
 from typing import Iterable, List, Tuple, Dict, Any
 import csv
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
 
 DEFAULT_ENCODING: str = "utf-8"
 


### PR DESCRIPTION
Prevents “No handler found” warnings; you can enable DEBUG when needed.