### PR TITLE
Improve _safe_div doc & name semantics

### DIFF
--- a/selector_report.py
+++ b/selector_report.py
@@ -71,6 +71,7 @@ def _confusion(
 
 
 def _safe_div(n: float, d: float) -> float:
+      """Return n / d, or 0.0 if d == 0."""
     return n / d if d else 0.0
 
 


### PR DESCRIPTION
Make it clear that it returns 0.0 on division by zero.