### PR TITLE
Ensure all human-readable prints go to stderr

### DIFF
--- a/selector_diff.py
+++ b/selector_diff.py
@@ -248,8 +248,8 @@ def main() -> None:
     delta = diff_blocks(snap_a, snap_b)
     elapsed = time.monotonic() - t0
 
-    # Human-readable summary
-    print("\n📦 ABI")
+       # Human-readable summary
+    print("\n📦 ABI", file=sys.stderr)
     print(f"  Functions: {len(abi_sels)}", file=sys.stderr)
 
     print("\n🔢 Snapshot A")


### PR DESCRIPTION
print("\n📦 ABI") going to stdout; everything else uses stderr