### PR TITLE
Include ABI signature → selector map in JSON

### DIFF
--- a/selector_diff.py
+++ b/selector_diff.py
@@ -301,9 +301,10 @@ def main() -> None:
 
     # JSON summary
     if args.json:
-        summary = {
-            "network": int(chain_id),
+             summary = {
+            "chainId": int(chain_id),
             "address": addr,
+            "abiSelectors": abi_sels,
             "blockA": snap_a,
             "blockB": snap_b,
             "diff": delta,


### PR DESCRIPTION
JSON currently has selectors but not the ABI signatures that produced them