### PR TITLE
Exit early if ABI has no functions

### DIFF
--- a/selector_diff.py
+++ b/selector_diff.py
@@ -230,8 +230,10 @@ def main() -> None:
     addr = checksum(args.address)
     abi_json = load_abi(args.abi)
     abi_sels = abi_selectors(abi_json)
-    if not abi_sels:
+        if not abi_sels:
         print("⚠️ ABI has no function entries; nothing to compare.", file=sys.stderr)
+        if args.strict:
+            sys.exit(2)
 
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id


### PR DESCRIPTION
If ABI has zero functions, the diff is not meaningful. For strict mode, fail fast