### PR TITLE
Add --quiet to suppress human-readable logs

### DIFF
--- a/selector_diff.py
+++ b/selector_diff.py
@@ -191,6 +191,11 @@ def diff_blocks(
 # --- CLI ------------------------------------------------------------------
 
 def parse_args() -> argparse.Namespace:
+        ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress human-readable logs (only JSON output if --json is set)",
+    )
     ap = argparse.ArgumentParser(
         description="Diff a contract's function selectors between two blocks.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,


### PR DESCRIPTION
When scripting/CI, sometimes you only want JSON on stdout