### PR TITLE
Warn on zero bytecode (selfdestruct / pre-deploy)

### DIFF
--- a/selector_history.py
+++ b/selector_history.py
@@ -115,6 +115,9 @@ def scan_block(
     """
     blk = w3.eth.get_block(block_number)
     code = w3.eth.get_code(address, block_identifier=block_number)
+    if not code:
+        # Probably pre-deployment or selfdestruct; still scan (will yield zero selectors)
+        pass
 
     abi_selectors = set(sig_map.values())
     byte_selectors = parse_push4_selectors(code)


### PR DESCRIPTION
If len(code) == 0 at a sampled block, highlight it.