### PR TITLE
Add per-record ABI mismatch flags

### DIFF
--- a/selector_history.py
+++ b/selector_history.py
@@ -317,6 +317,8 @@ def main() -> None:
                 "changedVsPrev": changed,
                 "gained": gained,
                 "lost": lost,
+                "hasMissing": len(info["missingInBytecode"]) > 0,
+                "hasExtra": len(info["extraInBytecode"]) > 0,
             }
             records.append(rec)
 


### PR DESCRIPTION
In JSON, precompute booleans for “has missing” / “has extra”.