### PR TITLE
Handle ABI with no "inputs" field robustly

### DIFF
--- a/selector_history.py
+++ b/selector_history.py
@@ -63,7 +63,7 @@ def abi_function_signatures(abi: List[Dict[str, Any]]) -> Dict[str, str]:
         name = entry.get("name")
         if not name:
             continue
-        inputs = entry.get("inputs", [])
+              inputs = entry.get("inputs") or []
         types = [inp.get("type", "unknown") for inp in inputs]
         signature = f"{name}({','.join(types)})"
         selector = keccak(text=signature)[:4].hex()


### PR DESCRIPTION
Some ABI entries may omit inputs.