### PR TITLE
Use monotonic time for fmt_utc calls in JSON timestamp

### DIFF
--- a/selector_history.py
+++ b/selector_history.py
@@ -356,6 +356,8 @@ def main() -> None:
             "startBlock": start,
             "endBlock": end,
             "step": args.step,
+                    # Use wall-clock time (UTC) for report generation timestamp
+        out = {
             "generatedAtUtc": fmt_utc(int(time.time())),
             "records": records,
         }


### PR DESCRIPTION
fmt_utc(int(time.time())) is fine, but a doc comment is nice