### PR TITLE
Add support for earliest block tag in the docstring

### DIFF
--- a/selector_snapshot.py
+++ b/selector_snapshot.py
@@ -1,3 +1,6 @@
+'''
+- Supports block numbers or tags like latest/finalized/safe/earliest/pending.
+'''
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
Your code supports it; make sure docs mention it (they already do). If you want to highlight it more, tweak the module docstring