### PR TITLE
Add sanity check for bytecodeLength == 0 in snapshot

### DIFF
--- a/selector_snapshot.py
+++ b/selector_snapshot.py
@@ -189,6 +189,7 @@ def main() -> None:
     byte_commit = selector_commitment(byte_selectors)
 
     snapshot = {
+        "hasBytecode": bool(code),
         "rpc": args.rpc,
         "chainId": int(chain_id),
         "address": addr,


### PR DESCRIPTION
Snapshot JSON already records bytecodeLength; you can add a boolean field for convenience